### PR TITLE
closes #6: Add support for getting proxy authentication from proxy url

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -175,6 +175,7 @@ defmodule Mix.Tasks.Compile.Tika do
     System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
   end
 
+  defp get_proxy_auth_from_proxy_url(nil), do: []
   defp get_proxy_auth_from_proxy_url(proxy_url) do
     parsed = URI.parse(proxy_url)
 


### PR DESCRIPTION
Add support for getting the proxy authentication username/password from
proxy url of the form http://username:password@ip:port