### PR TITLE
Drop compatibility with Elixir <= 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,24 @@
 language: elixir
 sudo: false
 
-# Elixir versions
 elixir:
-  - 1.1.1
-  - 1.2.6
-  - 1.3.4
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
 
-# Erlang versions
 otp_release:
-  - 17.5
-  - 18.1
-  - 19.1
+  - 19.3
+  - 20.3
+  - 21.0
 
+# Exclude unsupported Elixir/OTP combinations
 matrix:
   exclude:
-    # Elixir 1.1 doesn't support Erlang 19
-    - elixir: 1.1.1
-      otp_release: 19.1
+    - elixir: 1.5
+      otp_release: 21.0
+    - elixir: 1.4
+      otp_release: 21.0
 
 env:
   global:
@@ -32,8 +33,8 @@ after_success:
   - |
       test ${TRAVIS_PULL_REQUEST} == "false" && \
       test ${TRAVIS_BRANCH} == "master" && \
-      test "${TRAVIS_ELIXIR_VERSION}" == "1.3.4" && \
-      test "${TRAVIS_OTP_RELEASE}" == "19.1" && \
+      test "${TRAVIS_ELIXIR_VERSION}" == "1.6" && \
+      test "${TRAVIS_OTP_RELEASE}" == "21.0" && \
       ./push-docs.sh
 
 # Speed up the build by caching our dependencies and the downloaded Tika JAR.


### PR DESCRIPTION
`to_char_list` is deprecated, and we can't use `to_charlist` until version 1.4. This unblocks #7.